### PR TITLE
create mount to persist data on host - preventing loss of data after ddev stop

### DIFF
--- a/docker-compose.n8n.yaml
+++ b/docker-compose.n8n.yaml
@@ -21,6 +21,7 @@ services:
       - db
     volumes:
       - ".:/mnt/ddev_config"
+      - "./n8n/data:/home/node/.n8n"
       # only for mysql
       #- "./n8n/startup-script.sh:/startup-script.sh"
     environment:
@@ -35,7 +36,6 @@ services:
       #N8N_LOG_LEVEL: debug
       N8N_LOG_OUTPUT: "stdout"
       VIRTUAL_HOST: "$DDEV_HOSTNAME"
-      DB_SQLITE_DB_FILE: "/mnt/ddev_config/n8n/database.sqlite"
       #DB_TYPE: mysqldb
       #DB_MYSQLDB_HOST: db
       #DB_MYSQLDB_PORT: 3306

--- a/n8n/data/.gitignore
+++ b/n8n/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
DB_SQLITE_DB_FILE as environment variable was removed. it has no effect.
I asume the n8n documentation was missunderstood here. 

The data directory is created but all files are ignored. the data directory is mounted to the host.