### PR TITLE
Add dotenv support (ddev 1.23.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ Run `ddev describe` to list your project's services and their URLs.
 
 ## Configuration
 
+### Docker
+
+To modify the build of the used n8n image for the container there are dotenv variables available.
+
+- `N8N_TAG` - The used n8n image tag. Default is `latest`.
+
+Use the ddev dotenv command to set these variables.
+
+```bash
+ddev dotenv set .ddev/.env.n8n --n8n-tag=1.50.0
+```
+
 ### n8n Settings
 
 Settings are in general defined in the file `.ddev/docker-compose.n8n.yaml` via environment variables.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Run `ddev describe` to list your project's services and their URLs.
 To modify the build of the used n8n image for the container there are dotenv variables available.
 
 - `N8N_TAG` - The used n8n image tag. Default is `latest`.
+- `N8N_TIMEZONE` - The timezone of the n8n container. Default is `Europe/Berlin`.
+- `N8N_BASIC_AUTH_ACTIVE` - Enable basic authentication. Default is `false`.
+- `N8N_BASIC_AUTH_USER` - The basic authentication username. Default is `n8n`.
+- `N8N_BASIC_AUTH_PASSWORD` - The basic authentication password. Default is `n8n`.
+- `N8N_ENCRYPTION_KEY` - The encryption key for sensitive data. Default is `n8n`.
 
 Use the ddev dotenv command to set these variables.
 

--- a/docker-compose.n8n.yaml
+++ b/docker-compose.n8n.yaml
@@ -4,7 +4,7 @@ version: '3.6'
 services:
   n8n:
     container_name: ddev-${DDEV_SITENAME}-n8n
-    image: docker.n8n.io/n8nio/n8n:latest
+    image: docker.n8n.io/n8nio/n8n:${N8N_TAG:-latest}
     networks: [default, ddev_default]
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/docker-compose.n8n.yaml
+++ b/docker-compose.n8n.yaml
@@ -17,14 +17,14 @@ services:
     volumes:
       - ".:/mnt/ddev_config"
     environment:
-      GENERIC_TIMEZONE: "Europe/Berlin"
-      N8N_BASIC_AUTH_ACTIVE: false
-      N8N_BASIC_AUTH_USER: "n8n"
-      N8N_BASIC_AUTH_PASSWORD: "n8n"
+      GENERIC_TIMEZONE: "${N8N_TIMEZONE:-Europe/Berlin}"
+      N8N_BASIC_AUTH_ACTIVE: "${N8N_BASIC_AUTH_ACTIVE:-false}"
+      N8N_BASIC_AUTH_USER: "${N8N_BASIC_AUTH_USER:-n8n}"
+      N8N_BASIC_AUTH_PASSWORD: "${N8N_BASIC_AUTH_PASSWORD:-n8n}"
       N8N_HOST: "${DDEV_SITENAME}.ddev.site"
       N8N_PORT: 5678
       N8N_PROTOCOL: http
-      N8N_ENCRYPTION_KEY: "n8n"
+      N8N_ENCRYPTION_KEY: "${N8N_ENCRYPTION_KEY:-n8n}"
       N8N_USER_FOLDER: "/mnt/ddev_config/n8n/data"
       #N8N_LOG_LEVEL: debug
       N8N_LOG_OUTPUT: "stdout"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -25,7 +25,7 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
   if ! ddev restart; then
     ddev logs -s n8n
@@ -33,11 +33,12 @@ teardown() {
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   echo "# ddev get netz98/ddev-n8n with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get netz98/ddev-n8n
+  ddev add-on get netz98/ddev-n8n
   if ! ddev restart >/dev/null; then
     ddev logs -s n8n
   fi


### PR DESCRIPTION
Allow define the n8n version via `ddev dotenv` command.