### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,23 @@ This addon sets up a n8n instance for your DDEV project. n8n is a free and open 
 
 ## Installation
 
-1. Run `ddev get netz98/ddev-n8n` to install the addon in your exiting ddev project.
-2. `ddev restart` to restart your project.
+To install the addon in your existing DDEV project for DDEV v1.23.5 or above run
+
+```bash
+ddev add-on get netz98/ddev-n8n
+```
+
+For earlier versions of DDEV run
+
+```bash
+ddev get netz98/ddev-n8n
+```
+
+Then restart your project
+
+```bash
+ddev restart
+```
 
 ## Usage
 
@@ -60,4 +75,3 @@ It's disabled by default.
 
 You can enable it by changing the variable `N8N_BASIC_AUTH_ACTIVE` in `.ddev/docker-compose.n8n.yaml` to `true`. 
 The username and password can be configured in the same file.
-


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.