### PR TITLE
Change: update readme and tests with new dev addon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This addon sets up a n8n instance for your DDEV project. n8n is a free and open 
 
 ## Installation
 
-1. Run `ddev get netz98/ddev-n8n` to install the addon in your exiting ddev project.
+1. Run `ddev add-on get netz98/ddev-n8n` to install the addon in your exiting ddev project.
 2. `ddev restart` to restart your project.
+
+**Note:** For older versions of DDEV (prior to v1.23.5), use `ddev get netz98/ddev-n8n` instead of `ddev add-on get`.
 
 ## Usage
 
@@ -60,4 +62,3 @@ It's disabled by default.
 
 You can enable it by changing the variable `N8N_BASIC_AUTH_ACTIVE` in `.ddev/docker-compose.n8n.yaml` to `true`. 
 The username and password can be configured in the same file.
-

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,7 +26,7 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR}
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  ddev add-on get ${DIR}
   if ! ddev restart; then
     ddev logs -s n8n
   fi
@@ -37,7 +37,7 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get netz98/ddev-n8n with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  echo "# ddev add-on get netz98/ddev-n8n with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev add-on get netz98/ddev-n8n
   if ! ddev restart >/dev/null; then
     ddev logs -s n8n


### PR DESCRIPTION
Update installation instructions and tests to use `ddev add-on get` command.

* **README.md**
  - Change installation command to `ddev add-on get netz98/ddev-n8n`.
  - Add a note for older versions of DDEV to use `ddev get netz98/ddev-n8n`.

* **tests/test.bats**
  - Update test cases to use `ddev add-on get` instead of `ddev get`.

