### PR TITLE
fix: remove obsolete attribute `version`

### DIFF
--- a/docker-compose.n8n.yaml
+++ b/docker-compose.n8n.yaml
@@ -1,6 +1,5 @@
 # DDEV n8n recipe file.
 #ddev-generated
-version: '3.6'
 services:
   n8n:
     container_name: ddev-${DDEV_SITENAME}-n8n


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.n8n.yaml` file, removing the `version: '3.6'` declaration.

Fixes:
```shell
level=warning msg=".ddev/docker-compose.n8n.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
```